### PR TITLE
修复result数组中出现异常数据导致的panic

### DIFF
--- a/types.go
+++ b/types.go
@@ -514,6 +514,9 @@ type CallTracerByBlock []*struct {
 func (t *proxyCallTracerByBlock) toCallTracerByBlock() CallTracerByBlock {
 	result := make(CallTracerByBlock, 0, len(*t))
 	for i := range *t {
+		if (*t)[i].Result == nil {
+			continue
+		}
 		result = append(result, &struct{ Result *CallTracer }{Result: (*t)[i].Result.toCallTracer()})
 	}
 	return result


### PR DESCRIPTION
数组中出现这种数据 {
            "error":"TypeError: cannot read property 'toString' of undefined    in server-side tracer function 'result'"
        }导致程序panic